### PR TITLE
Support standardjs linter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "extends": "standard",
+  "globals": {
+    "assert": true,
+    "it": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -509,10 +509,12 @@ export const runStandardLinter = (contents, fix) => (
   })
 )
 
-export const formatLineLinterError = (error) => (
-  padRight(error.line + ':' + error.column + ': ', 10, ' ') +
-  padRight(error.filename, 20, ' ') +
-  error.message + ' ' + '(' + error.ruleId + ')'
+export const formatLinterErrorsColumnMode = (errors) => (
+  errors.map((error) => (
+    padRight(error.line + ':' + error.column + ': ', 10, ' ') +
+    padRight(error.filename, 20, ' ') +
+    error.message + ' ' + '(' + error.ruleId + ')'
+  )).join('\n')
 )
 
 export const formatLinterError = (line, filename, output) => (error) => {
@@ -523,7 +525,7 @@ export const formatLinterError = (line, filename, output) => (error) => {
 }
 
 export const printLinterErrors = (errors) => {
-  console.error(errors.map(formatLineLinterError).join('\n'))
+  console.error()
 }
 
 export const isFix = (options) => !!options._ && options._[0] === 'fix'
@@ -567,7 +569,7 @@ export async function runLinter (codeBlocks, options) {
     errors = [...errors, ...mapLinterErrorsToLine(results, line, filename)]
   })(codeBlocks)
   if (fix) await fixLinterErrors(errors, codeBlocks)
-  else printLinterErrors(errors)
+  else formatLinterErrorsColumnMode(errors)
 }
 
 export default runLinter
@@ -581,7 +583,7 @@ import {
   runStandardLinter,
   mapLinterErrorsToLine,
   countLinterErrors,
-  formatLineLinterError,
+  formatLinterErrorsColumnMode,
   isFix,
   generateCodeBlock
 } from './runLinter'
@@ -597,15 +599,15 @@ it('should map linter errors back to line in README.md', () => {
   assert(mappedReadme[0].message === 'message-1')
 })
 
-it('should format line linter error', () => {
-  const error = {
+it('should format linter errors on a column mode', () => {
+  const errors = [{
     line: 5,
     column: 10,
     message: 'message',
     filename: 'example.js',
     ruleId: 'ruleId'
-  }
-  const line = formatLineLinterError(error)
+  }]
+  const line = formatLinterErrorsColumnMode(errors)
   assert(line === '5:10:     example.js          message (ruleId)')
 })
 

--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ import Table from 'cli-table'
 export const countLinterErrors = (results) => results[0].messages.length
 
 export const runESLint = (contents, fix) => {
-  const cli = new CLIEngine({ fix })
+  const cli = new CLIEngine({ fix, globals: ['describe', 'it', 'should'] })
   const report = cli.executeOnText(contents)
   return report.results
 }

--- a/README.md
+++ b/README.md
@@ -502,23 +502,14 @@ export const paddingText = (width, string, padding = ' ') => {
 
 export const countLinterErrors = (results) => results[0].messages.length
 
-export const removeEslintDisable = (remover) => (result) => {
-  if (result.output) {
-    result.output = result.output.replace(remover, '')
-  }
-  return result
-}
-
 export const runStandardLinter = (contents, fix) => (
   new Promise((resolve, reject) => {
-    const disabledRules = ['no-undef', 'no-unused-vars', 'no-lone-blocks', 'no-labels']
-    const eslintDisable = '/* eslint-disable ' + disabledRules.join(', ') + ' */\n'
-    standard.lintText(eslintDisable + contents, { fix }, (err, { results }) => {
-      if (err) reject(err);
-      else resolve(results.map(removeEslintDisable(eslintDisable)))
-    });
+    standard.lintText(contents, { fix }, (err, { results }) => {
+      if (err) reject(err)
+      else resolve(results)
+    })
   })
-);
+)
 
 export const formatLineLinterError = (error) => (
   paddingText(10, error.line + ':' + error.column + ': ') +
@@ -593,7 +584,6 @@ import {
   countLinterErrors,
   isFix,
   insertCodeBlock,
-  removeEslintDisable,
   replaceAll
 } from './runLinter'
 
@@ -643,19 +633,6 @@ it('should insert javascript code block', () => {
     'const x = 5',
     '`' + '`' + '`'
   ].join('\n'))
-})
-
-it('should remove eslint-disable line', () => {
-  const eslintDisable = '/* eslint-disable some-rule */'
-  const input = {
-    output: [
-      eslintDisable,
-      '// OK'
-    ].join('\n')
-  }
-  const input2 = { output: '// ok' }
-  assert(removeEslintDisable(eslintDisable + '\n')(input).output === '// OK')
-  assert(removeEslintDisable(eslintDisable + '\n')(input2).output === '// ok')
 })
 
 it('should lint text with standard linter', async () => {

--- a/README.md
+++ b/README.md
@@ -524,10 +524,6 @@ export const formatLinterError = (line, filename, output) => (error) => {
   return error
 }
 
-export const printLinterErrors = (errors) => {
-  console.error()
-}
-
 export const isFix = (options) => !!options._ && options._[0] === 'fix'
 
 export const generateCodeBlock = (code, filename) => {
@@ -569,7 +565,7 @@ export async function runLinter (codeBlocks, options) {
     errors = [...errors, ...mapLinterErrorsToLine(results, line, filename)]
   })(codeBlocks)
   if (fix) await fixLinterErrors(errors, codeBlocks)
-  else formatLinterErrorsColumnMode(errors)
+  else console.error(formatLinterErrorsColumnMode(errors))
 }
 
 export default runLinter

--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ export default runUnitTests
 // runLinter.js
 import fs from 'fs'
 import saveToFile from './saveToFile'
-import padRight from 'pad-right'
+import padRight from 'lodash/padEnd'
 import flatten from 'lodash/flatten'
 import { CLIEngine } from 'eslint'
 

--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ export const formatLineLinterError = (error) => (
 export const formatLinterError = (line, filename, output) => (error) => {
   error.line += line - 1
   error.filename = filename
-  error.output = output
+  error.fixedCode = output
   return error
 }
 
@@ -554,10 +554,11 @@ export const replaceAll = (text, pattern, replace) => text.split(pattern).join(r
 
 export const fixLinterErrors = async (errors, codeBlocks, targetPath = 'README.md') => {
   let readme = fs.readFileSync(targetPath, 'utf8')
-  errors.map(({ filename, output }) => {
+  errors.map(({ filename, fixedCode }) => {
     const code = codeBlocks[filename].contents.replace(/\n$/g, '')
-    const fixedCode = output
-    readme = replaceAll(readme, insertCodeBlock(code, filename), insertCodeBlock(fixedCode, filename))
+    if (fixedCode) {
+      readme = replaceAll(readme, insertCodeBlock(code, filename), insertCodeBlock(fixedCode, filename))
+    }
   })
   await saveToFile(targetPath, readme)
 }
@@ -606,7 +607,7 @@ it('should format linter error', () => {
   const error = formatLinterError(5, 'example.js', 'const x = 5')({ line: 5 })
   assert(error.line === 9)
   assert(error.filename === 'example.js')
-  assert(error.output === 'const x = 5')
+  assert(error.fixedCode === 'const x = 5')
 })
 
 it('should count linter errors', () => {

--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ export const formatLinterErrorsColumnMode = (errors) => (
   )).join('\n')
 )
 
-export const formatLinterError = (line, filename, output) => (error) => {
+const formatLinterError = (line, filename, output) => (error) => {
   error.line += line - 1
   error.filename = filename
   error.fixedCode = output

--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ import fs from 'fs'
 import saveToFile from './saveToFile'
 import padRight from 'lodash/padEnd'
 import flatten from 'lodash/flatten'
+import isEmpty from 'lodash/isEmpty'
 import { CLIEngine } from 'eslint'
 import Table from 'cli-table'
 
@@ -508,6 +509,7 @@ export const runESLint = (contents, fix) => {
 }
 
 export const formatLinterErrorsColumnMode = (errors, resetStyle = {}) => {
+  if (isEmpty(errors)) return ''
   const table = new Table({ head: ['Where', 'Path', 'Rule', 'Message'], ...resetStyle })
   errors.map((error) => table.push([
     error.line + ':' + error.column,
@@ -616,6 +618,8 @@ it('should format linter errors on a column mode', () => {
     '│ 5:10  │ example.js │ ruleId-1 │ message │',
     '└───────┴────────────┴──────────┴─────────┘'
   ].join('\n'))
+  const tableNoErrors = formatLinterErrorsColumnMode([], resetStyle)
+  assert(tableNoErrors === '')
 })
 
 it('should trigger fix mode when \'fix\' option is given', () => {

--- a/README.md
+++ b/README.md
@@ -495,10 +495,7 @@ import fs from 'fs'
 import saveToFile from './saveToFile'
 import standard from 'standard'
 import forEachCodeBlock from './forEachCodeBlock'
-
-export const paddingText = (width, string, padding = ' ') => {
-  return (width <= string.length) ? string : paddingText(width, string + padding, padding)
-}
+import padRight from 'pad-right'
 
 export const countLinterErrors = (results) => results[0].messages.length
 
@@ -512,8 +509,8 @@ export const runStandardLinter = (contents, fix) => (
 )
 
 export const formatLineLinterError = (error) => (
-  paddingText(10, error.line + ':' + error.column + ': ') +
-  paddingText(20, error.filename) +
+  padRight(error.line + ':' + error.column + ': ', 10, ' ') +
+  padRight(error.filename, 20, ' ') +
   error.message + ' ' + '(' + error.ruleId + ')'
 )
 
@@ -577,7 +574,6 @@ And its tests
 ```js
 // runLinter.test.js
 import {
-  paddingText,
   runStandardLinter,
   formatLineLinterError,
   formatLinterError,
@@ -586,12 +582,6 @@ import {
   insertCodeBlock,
   replaceAll
 } from './runLinter'
-
-it('should create padding text', () => {
-  assert(paddingText(5, 'hello') === 'hello')
-  assert(paddingText(6, 'hello') === 'hello ')
-  assert(paddingText(7, 'hello', '_') === 'hello__')
-})
 
 it('should format linter error', () => {
   const error = formatLinterError(5, 'example.js', 'const x = 5')({ line: 5 })

--- a/README.md
+++ b/README.md
@@ -219,12 +219,6 @@ export const allowToUseESLint = (hasESLintModule) => {
   console.log('Please install eslint')
   process.exitCode = 1
 }
-export const cancelProcessExit = (callback) => (
-  process.on('exit', (code) => {
-    callback(code)
-    delete process.exitCode
-  })
-)
 ```
 
 
@@ -878,6 +872,12 @@ import * as buildCommand from './cli/buildCommand'
 import * as testCommand from './cli/testCommand'
 import * as lintCommand from './cli/lintCommand'
 
+const assertProcessExitCode = (expectedCode) => (
+  process.on('exit', (code) => {
+    assert(code === expectedCode)
+    delete process.exitCode
+  })
+)
 it('works', async () => {
   const example = fs.readFileSync('example.md', 'utf8')
   const eslintrc = fs.readFileSync('.eslintrc', 'utf8')
@@ -892,7 +892,7 @@ it('works', async () => {
     assert(fs.readFileSync('README.md', 'utf8') !== example)
     await lintCommand.handler({ _: ['fix'] })
     assert(fs.readFileSync('README.md', 'utf8') === example)
-    lintCommand.cancelProcessExit((code) => assert(code === 1))
+    assertProcessExitCode(1)
     lintCommand.allowToUseESLint(false)
   })
 })

--- a/README.md
+++ b/README.md
@@ -832,7 +832,7 @@ import * as lintCommand from './cli/lintCommand'
 it('works', async () => {
   const example = fs.readFileSync('example.md', 'utf8')
   await runInTemporaryDir(async () => {
-    fs.writeFileSync('README.md', example)
+    fs.writeFileSync('README.md', example.replace('a + b', 'a+b'))
     await buildCommand.handler({ })
     assert(fs.existsSync('src/add.js'))
     assert(fs.existsSync('lib/add.js'))
@@ -840,7 +840,7 @@ it('works', async () => {
     assert(fs.existsSync('coverage/lcov.info'))
     await lintCommand.handler({ _: ['fix'] })
     assert(fs.existsSync('README.md'))
-    assert(fs.readFileSync('README.md', 'utf8') === example)
+    assert(fs.readFileSync('README.md', 'utf8') !== example)
   })
 })
 

--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ export const fixLinterErrors = async (errors, codeBlocks, targetPath = 'README.m
   errors.map(({ filename, fixedCode }) => {
     const code = codeBlocks[filename].contents.replace(/\n$/g, '')
     if (fixedCode) {
-      readme = readme.replace(new RegExp(insertCodeBlock(code, filename), 'g'), insertCodeBlock(fixedCode, filename))
+      readme = readme.replace(new RegExp(generateCodeBlock(code, filename), 'g'), generateCodeBlock(fixedCode, filename))
     }
   })
   await saveToFile(targetPath, readme)

--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ export const printLinterErrors = (errors) => {
 
 export const isFix = (options) => !!options._ && options._[0] === 'fix'
 
-export const insertCodeBlock = (code, filename) => {
+export const generateCodeBlock = (code, filename) => {
   const END = '`' + '`' + '`'
   const BEGIN = END + 'js'
   return [
@@ -579,7 +579,7 @@ import {
   formatLinterError,
   countLinterErrors,
   isFix,
-  insertCodeBlock,
+  generateCodeBlock,
   replaceAll
 } from './runLinter'
 
@@ -617,7 +617,7 @@ it('should replace all matched substring with pattern', () => {
 })
 
 it('should insert javascript code block', () => {
-  assert(insertCodeBlock('const x = 5', 'example.js') === [
+  assert(generateCodeBlock('const x = 5', 'example.js') === [
     '`' + '`' + '`js',
     '// example.js',
     'const x = 5',

--- a/README.md
+++ b/README.md
@@ -501,8 +501,6 @@ import compact from 'lodash/compact'
 import { CLIEngine } from 'eslint'
 import Table from 'cli-table'
 
-export const countLinterErrors = (results) => results[0].messages.length
-
 export const runESLint = (contents, fix) => {
   const cli = new CLIEngine({ fix, globals: ['describe', 'it', 'should'] })
   const report = cli.executeOnText(contents)
@@ -591,7 +589,6 @@ And its tests
 import {
   runESLint,
   mapLinterErrorsToLine,
-  countLinterErrors,
   formatLinterErrorsColumnMode,
   isFix,
   generateCodeBlock
@@ -647,12 +644,6 @@ it('should insert javascript code block', () => {
     'const x = 5',
     '`' + '`' + '`'
   ].join('\n'))
-})
-
-it('should execute on text by `eslint-cli` and `eslint-config-standard`', () => {
-  assert(countLinterErrors(runESLint('1 === 2\n')) === 0)
-  assert(countLinterErrors(runESLint('1 === 2')) === 1)
-  assert(countLinterErrors(runESLint('1 == 2')) === 2)
 })
 
 ```

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
   },
   "scripts": {
     "build": "./build",
-    "prepublish": "npm run build",
-    "test": "./essay test"
+    "prepublish": "npm run lint && npm run build",
+    "test": "./essay test",
+    "lint": "./essay lint"
   },
   "files": [
     "lib",
@@ -33,6 +34,7 @@
     "mocha": "^2.4.5",
     "power-assert": "^1.4.0",
     "rimraf": "^2.5.2",
+    "standard": "^7.0.1",
     "yargs": "^4.7.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-2": "^6.5.0",
     "babel-runtime": "^6.6.1",
+    "eslint": "^3.9.1",
     "glob": "^7.0.3",
     "istanbul": "^0.4.3",
     "lodash": "^4.11.2",
@@ -36,13 +37,12 @@
     "pad-right": "^0.2.2",
     "power-assert": "^1.4.0",
     "rimraf": "^2.5.2",
-    "standard": "^8.5.0",
     "yargs": "^4.7.0"
   },
   "devDependencies": {
     "babel-polyfill": "^6.8.0",
-    "essay": "3.0.0-0",
-    "standard": "^8.5.0"
+    "eslint-config-standard": "^6.2.1",
+    "essay": "3.0.0-0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "lodash": "^4.11.2",
     "mkdirp": "^0.5.1",
     "mocha": "^2.4.5",
-    "pad-right": "^0.2.2",
     "power-assert": "^1.4.0",
     "rimraf": "^2.5.2",
     "yargs": "^4.7.0"

--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
     "mocha": "^2.4.5",
     "power-assert": "^1.4.0",
     "rimraf": "^2.5.2",
-    "standard": "^7.0.1",
+    "standard": "^8.5.0",
     "yargs": "^4.7.0"
   },
   "devDependencies": {
     "babel-polyfill": "^6.8.0",
     "essay": "3.0.0-0",
-    "standard": "^7.0.1"
+    "standard": "^8.5.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "./build",
     "prepublish": "npm run lint && npm run build",
     "test": "./essay test",
-    "lint": "./essay lint"
+    "lint": "./essay lint",
+    "lint-fix": "./essay lint fix"
   },
   "files": [
     "lib",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lodash": "^4.11.2",
     "mkdirp": "^0.5.1",
     "mocha": "^2.4.5",
+    "pad-right": "^0.2.2",
     "power-assert": "^1.4.0",
     "rimraf": "^2.5.2",
     "standard": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lodash": "^4.11.2",
     "mkdirp": "^0.5.1",
     "mocha": "^2.4.5",
+    "module-exists": "^0.1.1",
     "power-assert": "^1.4.0",
     "rimraf": "^2.5.2",
     "yargs": "^4.7.0"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-2": "^6.5.0",
     "babel-runtime": "^6.6.1",
+    "cli-table": "^0.3.1",
     "eslint": "^3.9.1",
     "glob": "^7.0.3",
     "istanbul": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
   "devDependencies": {
     "babel-polyfill": "^6.8.0",
     "eslint-config-standard": "^6.2.1",
+    "eslint-plugin-promise": "^3.3.1",
+    "eslint-plugin-standard": "^2.0.1",
     "essay": "3.0.0-0"
   },
   "repository": {


### PR DESCRIPTION
available commands
- `npm run lint` for running the linter 
- `npm run lint-fix` for fixing format javascript in markdown

inspired by [standard-markdown](https://github.com/zeke/standard-markdown)
